### PR TITLE
Add PHP plugin site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+uploads/
+config.php

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+Options -Indexes
+<FilesMatch "\.php$">
+    SetHandler application/x-httpd-php
+</FilesMatch>

--- a/admin.php
+++ b/admin.php
@@ -1,0 +1,111 @@
+<?php
+// Admin login and dashboard
+session_start();
+require 'db.php';
+$config = include 'config.php';
+
+// Handle login
+if (isset($_POST['username'], $_POST['password'])) {
+    if ($_POST['username'] === $config['admin_user'] && $_POST['password'] === $config['admin_pass']) {
+        $_SESSION['admin'] = true;
+        header('Location: admin.php');
+        exit;
+    } else {
+        $error = 'Ongeldige login';
+    }
+}
+
+// Logout
+if (isset($_GET['logout'])) {
+    session_destroy();
+    header('Location: admin.php');
+    exit;
+}
+
+if (!isset($_SESSION['admin'])): ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Login</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+<h1>Admin Login</h1>
+<?php if (!empty($error)) echo '<div class="alert alert-danger">'.$error.'</div>'; ?>
+<form method="post">
+    <div class="mb-3"><input class="form-control" name="username" placeholder="Username"></div>
+    <div class="mb-3"><input class="form-control" type="password" name="password" placeholder="Password"></div>
+    <button class="btn btn-primary" type="submit">Login</button>
+</form>
+</body>
+</html>
+<?php else:
+// Dashboard
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="container py-4">
+<h1>Welkom, admin</h1>
+<a class="btn btn-secondary" href="admin.php?logout=1">Logout</a>
+<hr>
+<h2>Plugin upload</h2>
+<form id="uploadForm" enctype="multipart/form-data">
+    <div class="mb-2"><input class="form-control" name="name" placeholder="Naam" required></div>
+    <div class="mb-2"><input class="form-control" name="version" placeholder="Versie" required></div>
+    <div class="mb-2"><input class="form-control" name="mc_version" placeholder="MC Versie" required></div>
+    <div class="mb-2"><textarea class="form-control" name="description" placeholder="Beschrijving" required></textarea></div>
+    <div class="mb-2"><input type="file" name="file" accept=".jar" required></div>
+    <div class="progress mb-2"><div id="bar" class="progress-bar" style="width:0%"></div></div>
+    <button class="btn btn-primary" type="submit">Upload</button>
+</form>
+<div id="uploadMsg" class="mt-2"></div>
+<hr>
+<h2>Plugins</h2>
+<table class="table" id="pluginTable">
+<thead><tr><th>Naam</th><th>Versie</th><th>Downloads</th></tr></thead>
+<tbody>
+<?php
+$stmt = $pdo->query('SELECT p.*, (SELECT COUNT(*) FROM downloads d WHERE d.plugin_id=p.id) as dl FROM plugins p');
+foreach ($stmt as $row) {
+    echo '<tr><td>'.htmlspecialchars($row['name']).'</td><td>'.htmlspecialchars($row['version']).'</td><td>'.$row['dl'].'</td></tr>';
+}
+?>
+</tbody>
+</table>
+<h2>Download statistieken</h2>
+<canvas id="chart" width="400" height="200"></canvas>
+<script>
+// Upload with progress bar
+const form=document.getElementById('uploadForm');
+form.addEventListener('submit',e=>{
+    e.preventDefault();
+    const xhr=new XMLHttpRequest();
+    xhr.open('POST','upload.php');
+    xhr.upload.onprogress=ev=>{
+        document.getElementById('bar').style.width=(ev.loaded/ev.total*100)+'%';
+    };
+    xhr.onload=()=>{
+        document.getElementById('uploadMsg').innerText=xhr.responseText;
+        document.getElementById('bar').style.width='0%';
+    };
+    xhr.send(new FormData(form));
+});
+
+// Chart data via AJAX
+fetch('stats.php').then(r=>r.json()).then(data=>{
+    new Chart(document.getElementById('chart'),{
+        type:'line',
+        data:{labels:data.labels,datasets:[{label:'Downloads',data:data.counts}]},
+    });
+});
+</script>
+</body>
+</html>
+<?php endif; ?>

--- a/config.sample.php
+++ b/config.sample.php
@@ -1,0 +1,11 @@
+<?php
+// Sample configuration file. Copy to config.php and adjust.
+return [
+    'db_host' => 'localhost',
+    'db_name' => 'mcplugins',
+    'db_user' => 'root',
+    'db_pass' => 'password',
+    'admin_user' => 'admin',
+    'admin_pass' => 'secret'
+];
+?>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,14 @@
+<?php
+// Database connection using PDO
+$config = include __DIR__.'/config.php';
+
+try {
+    $dsn = 'mysql:host='.$config['db_host'].';dbname='.$config['db_name'].';charset=utf8mb4';
+    $pdo = new PDO($dsn, $config['db_user'], $config['db_pass'], [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
+    ]);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+?>

--- a/download.php
+++ b/download.php
@@ -1,0 +1,25 @@
+<?php
+// Serve jar and track downloads
+session_start();
+require 'db.php';
+
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT * FROM plugins WHERE id=?');
+$stmt->execute([$id]);
+$plugin = $stmt->fetch();
+if (!$plugin) {
+    http_response_code(404);
+    exit('Niet gevonden');
+}
+
+// Log download
+$pdo->prepare('INSERT INTO downloads (plugin_id, downloaded_at) VALUES (?, NOW())')->execute([$id]);
+
+if (!is_file($plugin['file_path'])) {
+    exit('Bestand ontbreekt');
+}
+
+header('Content-Type: application/java-archive');
+header('Content-Disposition: attachment; filename="'.basename($plugin['file_path']).'"');
+readfile($plugin['file_path']);
+?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,36 @@
+<?php
+// Public plugin list
+session_start();
+require 'db.php';
+
+$stmt = $pdo->query('SELECT * FROM plugins ORDER BY created_at DESC');
+$plugins = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Minecraft Plugins</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+<h1>Plugin lijst</h1>
+<table class="table">
+    <thead>
+        <tr><th>Naam</th><th>Versie</th><th>MC Versie</th><th>Beschrijving</th><th></th></tr>
+    </thead>
+    <tbody>
+        <?php foreach ($plugins as $p): ?>
+        <tr>
+            <td><?= htmlspecialchars($p['name']) ?></td>
+            <td><?= htmlspecialchars($p['version']) ?></td>
+            <td><?= htmlspecialchars($p['mc_version']) ?></td>
+            <td><?= nl2br(htmlspecialchars($p['description'])) ?></td>
+            <td><a class="btn btn-primary" href="download.php?id=<?= $p['id'] ?>">Download</a></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+<a href="admin.php">Admin login</a>
+</body>
+</html>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,17 @@
+-- SQL script to create tables
+CREATE TABLE plugins (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255),
+    version VARCHAR(50),
+    mc_version VARCHAR(50),
+    description TEXT,
+    file_path VARCHAR(255),
+    created_at DATETIME
+);
+
+CREATE TABLE downloads (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    plugin_id INT,
+    downloaded_at DATETIME,
+    FOREIGN KEY (plugin_id) REFERENCES plugins(id) ON DELETE CASCADE
+);

--- a/stats.php
+++ b/stats.php
@@ -1,0 +1,16 @@
+<?php
+// Return JSON with download counts per day for last 7 days
+session_start();
+require 'db.php';
+
+$rows = $pdo->query("SELECT DATE(downloaded_at) as d, COUNT(*) as c FROM downloads WHERE downloaded_at >= DATE_SUB(CURDATE(), INTERVAL 7 DAY) GROUP BY d ORDER BY d")->fetchAll();
+
+$labels = [];
+$counts = [];
+foreach ($rows as $r) {
+    $labels[] = $r['d'];
+    $counts[] = (int)$r['c'];
+}
+header('Content-Type: application/json');
+echo json_encode(['labels'=>$labels,'counts'=>$counts]);
+?>

--- a/upload.php
+++ b/upload.php
@@ -1,0 +1,36 @@
+<?php
+// Handle plugin upload via AJAX
+session_start();
+require 'db.php';
+
+if (!isset($_SESSION['admin'])) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+$name = $_POST['name'] ?? '';
+$version = $_POST['version'] ?? '';
+$mc_version = $_POST['mc_version'] ?? '';
+$description = $_POST['description'] ?? '';
+$file = $_FILES['file'] ?? null;
+
+if (!$file || $file['error'] !== UPLOAD_ERR_OK) {
+    exit('Fout bij upload');
+}
+
+// Validate file
+if (pathinfo($file['name'], PATHINFO_EXTENSION) !== 'jar') {
+    exit('Alleen .jar toegestaan');
+}
+if ($file['size'] > 5 * 1024 * 1024) {
+    exit('Bestand te groot');
+}
+
+$target = 'uploads/'.time().'_'.basename($file['name']);
+move_uploaded_file($file['tmp_name'], $target);
+
+$stmt = $pdo->prepare('INSERT INTO plugins (name, version, mc_version, description, file_path, created_at) VALUES (?,?,?,?,?,NOW())');
+$stmt->execute([$name, $version, $mc_version, $description, $target]);
+
+echo 'Upload succesvol';
+?>


### PR DESCRIPTION
## Summary
- implement a small PHP/MySQL plugin hosting site
- show admin login and dashboard with chart
- handle file uploads and downloads with logging
- provide database connection and schema

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a56fb55c8329923c198c037f117a